### PR TITLE
Add sensor visualizer index page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,1 @@
+/* Placeholder styles */

--- a/index.html
+++ b/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Device Sensor Visualizer</title>
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <h1>Device Sensor Visualizer</h1>
+  <p>This page displays live data from your device sensors and renders a 3D orientation view. Please grant motion and orientation permissions when prompted.</p>
+
+  <label for="sensorSelector">Select sensor:</label>
+  <select id="sensorSelector">
+    <option value="Accelerometer">Accelerometer</option>
+    <option value="GravitySensor">GravitySensor</option>
+    <option value="Gyroscope">Gyroscope</option>
+    <option value="LinearAccelerationSensor">LinearAccelerationSensor</option>
+    <option value="OrientationSensor">OrientationSensor</option>
+    <option value="RelativeOrientationSensor">RelativeOrientationSensor</option>
+  </select>
+
+  <div class="charts">
+    <canvas id="chart-x"></canvas>
+    <canvas id="chart-y"></canvas>
+    <canvas id="chart-z"></canvas>
+    <canvas id="chart-3d"></canvas>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.150.1/build/three.min.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,1 @@
+// Placeholder for sensor data visualization logic


### PR DESCRIPTION
## Summary
- Add initial `index.html` with sensor selector, canvas charts, and script references
- Stub out `css/styles.css` and `js/app.js`

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a75d8a07988324914e0cef7f146d9b