### PR TITLE
feat: add tailwind layout and themes

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,1 +1,53 @@
-/* Placeholder styles */
+/* Layout container for charts */
+.charts {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+/* Place 3D canvas below the three axis charts */
+#chart-3d {
+  grid-column: 1 / -1;
+  height: 300px;
+}
+
+/* Responsive canvas sizing */
+canvas {
+  width: 100%;
+  height: 200px;
+}
+
+/* Typography for sensor selector */
+label,
+select {
+  font-size: 1rem;
+}
+
+@media (min-width: 768px) {
+  canvas {
+    height: 300px;
+  }
+
+  #chart-3d {
+    height: 400px;
+  }
+
+  label,
+  select {
+    font-size: 1.25rem;
+  }
+}
+
+/* Light/Dark theme */
+body {
+  background-color: #f9fafb;
+  color: #111827;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #111827;
+    color: #f9fafb;
+  }
+}
+

--- a/index.html
+++ b/index.html
@@ -4,21 +4,24 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Device Sensor Visualizer</title>
+  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="css/styles.css">
 </head>
-<body>
-  <h1>Device Sensor Visualizer</h1>
-  <p>This page displays live data from your device sensors and renders a 3D orientation view. Please grant motion and orientation permissions when prompted.</p>
+<body class="min-h-screen p-4 bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+  <h1 class="text-2xl font-bold mb-4">Device Sensor Visualizer</h1>
+  <p class="mb-4">This page displays live data from your device sensors and renders a 3D orientation view. Please grant motion and orientation permissions when prompted.</p>
 
-  <label for="sensorSelector">Select sensor:</label>
-  <select id="sensorSelector">
-    <option value="Accelerometer">Accelerometer</option>
-    <option value="GravitySensor">GravitySensor</option>
-    <option value="Gyroscope">Gyroscope</option>
-    <option value="LinearAccelerationSensor">LinearAccelerationSensor</option>
-    <option value="OrientationSensor">OrientationSensor</option>
-    <option value="RelativeOrientationSensor">RelativeOrientationSensor</option>
-  </select>
+  <div class="mb-4">
+    <label for="sensorSelector" class="mr-2 font-medium">Select sensor:</label>
+    <select id="sensorSelector" class="border rounded p-1">
+      <option value="Accelerometer">Accelerometer</option>
+      <option value="GravitySensor">GravitySensor</option>
+      <option value="Gyroscope">Gyroscope</option>
+      <option value="LinearAccelerationSensor">LinearAccelerationSensor</option>
+      <option value="OrientationSensor">OrientationSensor</option>
+      <option value="RelativeOrientationSensor">RelativeOrientationSensor</option>
+    </select>
+  </div>
 
   <div class="charts">
     <canvas id="chart-x"></canvas>


### PR DESCRIPTION
## Summary
- load Tailwind via CDN and style page container
- implement responsive grid for axis charts and 3D view
- add light/dark themes, canvas sizing, and label typography

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7614548b48324adbf4117362d2819