### PR TITLE
Add motion permission activation button

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,9 @@
   <h1 class="text-2xl font-bold mb-4">Device Sensor Visualizer</h1>
   <p class="mb-4">This page displays live data from your device sensors and renders a 3D orientation view. Please grant motion and orientation permissions when prompted.</p>
 
+  <button id="enableMotion" class="mb-4 px-4 py-2 bg-blue-500 text-white rounded">Enable Motion</button>
+  <div id="message" class="mb-4 text-red-600"></div>
+
   <div class="mb-4">
     <label for="sensorSelector" class="mr-2 font-medium">Select sensor:</label>
     <select id="sensorSelector" class="border rounded p-1">

--- a/js/app.js
+++ b/js/app.js
@@ -15,9 +15,11 @@ class SensorController {
     this.labelBuffer = [];
 
     // Element for displaying messages
-    this.messageEl = document.createElement('div');
+    this.messageEl = document.getElementById('message') || document.createElement('div');
     this.messageEl.id = 'message';
-    document.body.appendChild(this.messageEl);
+    if (!this.messageEl.parentElement) {
+      document.body.appendChild(this.messageEl);
+    }
 
     this.createCharts();
     this.init3DScene();
@@ -167,5 +169,35 @@ class SensorController {
 }
 
 window.addEventListener('DOMContentLoaded', () => {
-  new SensorController();
+  const button = document.getElementById('enableMotion');
+  const messageEl = document.getElementById('message');
+
+  button.addEventListener('click', async () => {
+    messageEl.textContent = '';
+
+    const motionPerm = typeof DeviceMotionEvent !== 'undefined' && typeof DeviceMotionEvent.requestPermission === 'function';
+    const orientationPerm = typeof DeviceOrientationEvent !== 'undefined' && typeof DeviceOrientationEvent.requestPermission === 'function';
+
+    try {
+      if (motionPerm) {
+        const res = await DeviceMotionEvent.requestPermission();
+        if (res !== 'granted') throw new Error('denied');
+      }
+      if (orientationPerm) {
+        const res = await DeviceOrientationEvent.requestPermission();
+        if (res !== 'granted') throw new Error('denied');
+      }
+    } catch (err) {
+      messageEl.textContent = 'Permission to access motion/orientation was denied.';
+      return;
+    }
+
+    if (!motionPerm && !orientationPerm && (typeof DeviceMotionEvent === 'undefined' || typeof DeviceOrientationEvent === 'undefined')) {
+      messageEl.textContent = 'Motion and orientation APIs are not available on this device.';
+      return;
+    }
+
+    button.style.display = 'none';
+    new SensorController();
+  });
 });


### PR DESCRIPTION
## Summary
- Add an "Enable Motion" button to request device motion/orientation access before starting sensors
- Handle permission requests in app.js, hiding the button on success and reporting errors otherwise

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7701db7888324853c9532f50b4ce1