### PR TITLE
Stack charts vertically on small screens

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -17,6 +17,20 @@ canvas {
   height: 200px;
 }
 
+@media (max-width: 640px) {
+  .charts {
+    grid-template-columns: 1fr;
+  }
+
+  canvas {
+    height: 12vh;
+  }
+
+  #chart-3d {
+    height: 24vh;
+  }
+}
+
 /* Typography for sensor selector */
 label,
 select {


### PR DESCRIPTION
## Summary
- Stack sensor charts vertically on small screens using a max-width 640px media query
- Use viewport-relative heights so button and selector remain visible

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a77661a1f08324b308a32428b49346