### PR TITLE
Add responsive results display with jump chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
       style="top:50%;left:50%;transform:translate(-50%,-50%);"></div>
   </div>
 
+  <div id="results" class="mt-6 w-full max-w-md flex flex-col gap-4"></div>
+
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/webmidi"></script>
   <script type="module" src="js/jumpApp.js"></script>


### PR DESCRIPTION
## Summary
- Add results container in main page for displaying jump analysis
- Render responsive metric cards and acceleration chart after jump detection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a79400a3f08324b5bd27b2d31f5d65