### PR TITLE
Tune double tap and sensor thresholds

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/webmidi"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sensor-polyfills@0.6.2/dist/sensor-polyfills.umd.js"></script>
   <script type="module" src="js/jumpApp.js"></script>
 </body>
 </html>

--- a/js/JumpMetrics.js
+++ b/js/JumpMetrics.js
@@ -133,7 +133,7 @@ export function summarizeSeries(events, g = G0) {
  *
  * @param {Element|string} target - Elemento DOM o selector CSS.
  * @param {Function} [onDoubleTap] - Callback opcional al detectar doble toque.
- * @param {number} [thresholdMs=350] - Máxima separación entre toques (ms).
+ * @param {number} [thresholdMs=400] - Máxima separación entre toques (ms).
  * @returns {Function} Función para desuscribir (remover listeners).
  *
  * @example
@@ -145,7 +145,7 @@ export function summarizeSeries(events, g = G0) {
  */
 export function createDoubleTapTrigger(target, onDoubleTap = () => {
   console.log('⏺️ Doble toque detectado: iniciar captura');
-}, thresholdMs = 350) {
+}, thresholdMs = 400) {
   const el = typeof target === 'string' ? document.querySelector(target) : target;
   if (!el) throw new Error('createDoubleTapTrigger: no se encontró el elemento objetivo.');
 


### PR DESCRIPTION
## Summary
- increase double-tap detection window to 400 ms for better mobile recognition
- lower motion thresholds in jump detection to improve sensor sensitivity
- load sensor polyfills and use Generic Sensor API when available
- hide permission button on Android and request motion/orientation access on iOS

## Testing
- `node --check js/jumpApp.js`
- `npm test` *(fails: ENOENT missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a797e5ff0883249e40ce91f0a28b34