### PR TITLE
Agregar fondo rojo y cuenta regresiva al iniciar captura

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,8 @@
 
   <div id="results" class="mt-6 w-full max-w-md flex flex-col gap-4"></div>
 
+  <div id="countdown" class="hidden fixed inset-0 flex items-center justify-center text-white text-8xl font-bold"></div>
+
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/webmidi"></script>
   <script src="https://cdn.jsdelivr.net/npm/sensor-polyfills@0.6.2/dist/sensor-polyfills.umd.js"></script>

--- a/js/jumpApp.js
+++ b/js/jumpApp.js
@@ -11,6 +11,9 @@ const permBtn = document.getElementById('perm-btn');
 const dotEl = document.getElementById('dot');
 const demoArea = document.getElementById('demo-area');
 const resultsDiv = document.getElementById('results');
+const countdownEl = document.getElementById('countdown');
+const bodyEl = document.body;
+const defaultBg = getComputedStyle(bodyEl).backgroundColor;
 
 const isIOS = /iP(ad|hone|od)/i.test(navigator.userAgent);
 const hasSensorAPI = 'LinearAccelerationSensor' in window;
@@ -222,6 +225,8 @@ function resetApp() {
   if (isIOS) {
     permBtn.classList.remove('hidden');
   }
+  bodyEl.style.backgroundColor = defaultBg;
+  countdownEl.classList.add('hidden');
 }
 
 function initAudio() {
@@ -258,6 +263,19 @@ function playBeepSequence() {
       osc.stop(now + t + 0.15);
     });
   }
+}
+
+function startCountdown() {
+  const numbers = ['3', '2', '1'];
+  countdownEl.classList.remove('hidden');
+  numbers.forEach((num, i) => {
+    setTimeout(() => {
+      countdownEl.textContent = num;
+      if (i === numbers.length - 1) {
+        setTimeout(() => countdownEl.classList.add('hidden'), 200);
+      }
+    }, i * 200);
+  });
 }
 
 function handleMotion(ev) {
@@ -326,9 +344,13 @@ function onDoubleTap() {
   if (!permissionGranted) return;
   if (!capturing) {
     playBeepSequence();
+    startCountdown();
+    bodyEl.style.backgroundColor = 'rgba(255,0,0,0.3)';
     startCapture();
   } else {
     stopCapture();
+    bodyEl.style.backgroundColor = defaultBg;
+    countdownEl.classList.add('hidden');
   }
 }
 


### PR DESCRIPTION
## Summary
- Resalta la captura activada con doble tap cambiando el fondo a rojo suave y restaurándolo al finalizar.
- Muestra una cuenta regresiva grande sincronizada con los pitidos iniciales.

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a62bc600832493ab55476fcf3768