### PR TITLE
Increase Y-axis noise threshold

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -215,7 +215,7 @@ class SensorController {
       this.labelBuffer.shift();
     }
 
-    const axes = { x, y, z };
+    const axes = { x, y: Math.abs(y) < 3 ? 0 : y, z };
     Object.keys(axes).forEach(axis => {
       const buffer = this.dataBuffers[axis];
       buffer.push(axes[axis]);

--- a/js/jumpApp.js
+++ b/js/jumpApp.js
@@ -30,7 +30,8 @@ let sensorListening = false;
 
 const TAP_THRESHOLD = 15; // m/s^2 above gravity
 const TAP_WINDOW = 400; // ms between taps
-const NOISE_FLOOR = 0.1; // m/s^2 filter to ignore noise
+const NOISE_FLOOR = 0.1; // m/s^2 filter to ignore noise on X/Z
+const NOISE_FLOOR_Y = 3; // m/s^2 filter to ignore noise on Y
 
 function dotProd(a, b) {
   return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
@@ -291,7 +292,7 @@ function startCountdown(onEnd) {
 function filterNoise(ax, ay, az) {
   return {
     ax: Math.abs(ax) < NOISE_FLOOR ? 0 : ax,
-    ay: Math.abs(ay) < NOISE_FLOOR ? 0 : ay,
+    ay: Math.abs(ay) < NOISE_FLOOR_Y ? 0 : ay,
     az: Math.abs(az) < NOISE_FLOOR ? 0 : az,
   };
 }


### PR DESCRIPTION
## Summary
- Filter out small y-axis sensor values by treating magnitudes under 3 as noise.
- Document explicit 3 m/s² noise floor for Y-axis in jump detection.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ad13a7288324b0f1e28317f89caa