### PR TITLE
Add help modal with phone placement instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
   <button id="perm-btn" class="bg-blue-500 text-white px-4 py-2 rounded mb-4">
     Permisos de movimiento
   </button>
+  <button id="help-btn" class="bg-gray-500 text-white px-4 py-2 rounded mb-4">
+    Ayuda
+  </button>
   <div id="demo-area" class="relative w-64 h-64 bg-white border rounded">
     <div id="dot" class="absolute w-4 h-4 bg-red-500 rounded-full"
       style="top:50%;left:50%;transform:translate(-50%,-50%);"></div>
@@ -25,9 +28,27 @@
   <div id="countdown" class="hidden fixed inset-0 flex items-center justify-center text-white text-8xl font-bold"></div>
   <div id="sensor-led" class="fixed top-2 right-2 w-4 h-4 rounded-full bg-red-500 shadow"></div>
 
+  <div id="help-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+    <div class="bg-white p-6 rounded shadow max-w-sm text-center">
+      <h2 class="text-xl font-bold mb-4">Cómo colocar el teléfono</h2>
+      <p class="mb-4">Sujeta el teléfono firmemente en la parte baja de la espalda, a la altura de la cintura, con la pantalla hacia afuera. Utiliza un cinturón o banda elástica para mantenerlo inmóvil durante la prueba.</p>
+      <button id="close-help" class="bg-blue-500 text-white px-4 py-2 rounded">Cerrar</button>
+    </div>
+  </div>
+
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/webmidi"></script>
   <script src="https://cdn.jsdelivr.net/npm/sensor-polyfills@0.6.2/dist/sensor-polyfills.umd.js"></script>
   <script type="module" src="js/jumpApp.js"></script>
+  <script>
+    const helpBtn = document.getElementById('help-btn');
+    const helpModal = document.getElementById('help-modal');
+    const closeHelp = document.getElementById('close-help');
+    helpBtn.addEventListener('click', () => helpModal.classList.remove('hidden'));
+    closeHelp.addEventListener('click', () => helpModal.classList.add('hidden'));
+    helpModal.addEventListener('click', (e) => {
+      if (e.target === helpModal) helpModal.classList.add('hidden');
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add help button to open a modal with usage instructions
- display guidance on securing phone to lower back for measurements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7af7953ec8324be2638ccfc6332f7