### PR TITLE
Adjust metric and double tap thresholds

### DIFF
--- a/js/JumpMetrics.js
+++ b/js/JumpMetrics.js
@@ -133,7 +133,7 @@ export function summarizeSeries(events, g = G0) {
  *
  * @param {Element|string} target - Elemento DOM o selector CSS.
  * @param {Function} [onDoubleTap] - Callback opcional al detectar doble toque.
- * @param {number} [thresholdMs=400] - Máxima separación entre toques (ms).
+ * @param {number} [thresholdMs=500] - Máxima separación entre toques (ms).
  * @returns {Function} Función para desuscribir (remover listeners).
  *
  * @example
@@ -145,7 +145,7 @@ export function summarizeSeries(events, g = G0) {
  */
 export function createDoubleTapTrigger(target, onDoubleTap = () => {
   console.log('⏺️ Doble toque detectado: iniciar captura');
-}, thresholdMs = 400) {
+}, thresholdMs = 500) {
   const el = typeof target === 'string' ? document.querySelector(target) : target;
   if (!el) throw new Error('createDoubleTapTrigger: no se encontró el elemento objetivo.');
 

--- a/js/app.js
+++ b/js/app.js
@@ -1,3 +1,5 @@
+const Y_METRIC_THRESHOLD = 3; // Only pass Y values greater than this
+
 class SensorController {
   constructor() {
     this.sensorMap = {
@@ -215,7 +217,7 @@ class SensorController {
       this.labelBuffer.shift();
     }
 
-    const axes = { x, y: Math.abs(y) < 3 ? 0 : y, z };
+    const axes = { x, y: Math.abs(y) < Y_METRIC_THRESHOLD ? 0 : y, z };
     Object.keys(axes).forEach(axis => {
       const buffer = this.dataBuffers[axis];
       buffer.push(axes[axis]);

--- a/js/jumpApp.js
+++ b/js/jumpApp.js
@@ -28,10 +28,10 @@ let accelSensor;
 let lastTapTs = 0;
 let sensorListening = false;
 
-const TAP_THRESHOLD = 15; // m/s^2 above gravity
-const TAP_WINDOW = 400; // ms between taps
+const TAP_THRESHOLD = 1; // m/s^2 above gravity
+const TAP_WINDOW = 500; // max ms between taps
 const NOISE_FLOOR = 0.1; // m/s^2 filter to ignore noise on X/Z
-const NOISE_FLOOR_Y = 3; // m/s^2 filter to ignore noise on Y
+const NOISE_FLOOR_Y = 3; // only keep Y values greater than this
 
 function dotProd(a, b) {
   return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];


### PR DESCRIPTION
## Summary
- Only plot Y-axis values above 3 by introducing `Y_METRIC_THRESHOLD`
- Increase double tap window to 500ms and lower tap magnitude threshold to 1
- Align double tap utility with 500ms default separation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b177ba6c8324b0c1a3d2aea91a2b