### PR TITLE
Improve countdown visibility and double tap cooldown

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 
   <div id="results" class="mt-6 w-full max-w-md flex flex-col gap-4"></div>
 
-  <div id="countdown" class="hidden fixed inset-0 flex items-center justify-center text-white text-8xl font-bold"></div>
+  <div id="countdown" class="hidden fixed inset-0 flex items-center justify-center text-black text-8xl font-bold"></div>
   <div id="sensor-led" class="fixed top-2 right-2 w-4 h-4 rounded-full bg-red-500 shadow"></div>
 
   <div id="help-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">

--- a/js/jumpApp.js
+++ b/js/jumpApp.js
@@ -26,10 +26,12 @@ let midiOutput;
 let chart;
 let accelSensor;
 let lastTapTs = 0;
+let nextTapAllowedAt = 0;
 let sensorListening = false;
 
 const TAP_THRESHOLD = 1; // m/s^2 above gravity
 const TAP_WINDOW = 500; // max ms between taps
+const TAP_COOLDOWN = 3000; // ms to wait before next double tap
 const NOISE_FLOOR = 0.1; // m/s^2 filter to ignore noise on X/Z
 const NOISE_FLOOR_Y = 3; // only keep Y values greater than this
 
@@ -298,6 +300,7 @@ function filterNoise(ax, ay, az) {
 }
 
 function checkTap(f, timestamp) {
+  if (timestamp < nextTapAllowedAt) return;
   const mag = Math.hypot(f.ax, f.ay, f.az);
   const delta = hasSensorAPI ? mag : Math.abs(mag - 9.81);
   if (delta > TAP_THRESHOLD) {
@@ -381,14 +384,17 @@ function stopCapture() {
 function onDoubleTap() {
   if (!permissionGranted) return;
   if (!capturing) {
+    nextTapAllowedAt = performance.now() + TAP_COOLDOWN; // ignore taps during countdown
     startCountdown(() => {
       bodyEl.style.backgroundColor = 'rgba(255,0,0,0.3)';
       startCapture();
+      nextTapAllowedAt = performance.now() + TAP_COOLDOWN; // wait 3s before allowing stop
     });
   } else {
     stopCapture();
     bodyEl.style.backgroundColor = defaultBg;
     countdownEl.classList.add('hidden');
+    nextTapAllowedAt = performance.now() + TAP_COOLDOWN; // wait 3s before new start
   }
 }
 


### PR DESCRIPTION
## Summary
- Make countdown text black for visibility against white background
- Add 3 second cooldown before recognizing subsequent double taps

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b5939b5c83249f4ee5721837e78b