### PR TITLE
Add help image, live Y-axis label, and externalized settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,8 @@
       style="top:50%;left:50%;transform:translate(-50%,-50%);"></div>
   </div>
 
+  <label id="y-label" class="mt-2 block text-center">Y: <span id="y-value">0</span></label>
+
   <div id="results" class="mt-6 w-full max-w-md flex flex-col gap-4"></div>
 
   <div id="countdown" class="hidden fixed inset-0 flex items-center justify-center text-black text-8xl font-bold"></div>
@@ -31,6 +33,7 @@
   <div id="help-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
     <div class="bg-white p-6 rounded shadow max-w-sm text-center">
       <h2 class="text-xl font-bold mb-4">Cómo colocar el teléfono</h2>
+      <img src="img/help.png" alt="Cómo colocar el teléfono" class="mx-auto mb-4" />
       <p class="mb-4">Sujeta el teléfono firmemente en la parte baja de la espalda, a la altura de la cintura, con la pantalla hacia afuera. Utiliza un cinturón o banda elástica para mantenerlo inmóvil durante la prueba.</p>
       <button id="close-help" class="bg-blue-500 text-white px-4 py-2 rounded">Cerrar</button>
     </div>

--- a/js/jumpApp.js
+++ b/js/jumpApp.js
@@ -5,9 +5,17 @@ import {
   rsi,
   summarizeSeries,
 } from './JumpMetrics.js';
+import {
+  TAP_THRESHOLD,
+  TAP_WINDOW,
+  TAP_COOLDOWN,
+  NOISE_FLOOR,
+  NOISE_FLOOR_Y,
+} from './settings.js';
 
 const permBtn = document.getElementById('perm-btn');
 const dotEl = document.getElementById('dot');
+const yValueEl = document.getElementById('y-value');
 const resultsDiv = document.getElementById('results');
 const countdownEl = document.getElementById('countdown');
 const ledEl = document.getElementById('sensor-led');
@@ -28,12 +36,6 @@ let accelSensor;
 let lastTapTs = 0;
 let nextTapAllowedAt = 0;
 let sensorListening = false;
-
-const TAP_THRESHOLD = 15; // m/s^2 above gravity
-const TAP_WINDOW = 400; // max ms between taps
-const TAP_COOLDOWN = 3000; // ms to wait before next double tap
-const NOISE_FLOOR = 0.1; // m/s^2 filter to ignore noise on X/Z
-const NOISE_FLOOR_Y = 3; // only keep Y values greater than this
 
 function dotProd(a, b) {
   return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
@@ -317,6 +319,7 @@ function processMotion(ev) {
   const acc = ev.accelerationIncludingGravity || ev.acceleration || {};
   const now = ev.timeStamp;
   const f = filterNoise(acc.x || 0, acc.y || 0, acc.z || 0);
+  yValueEl.textContent = f.ay.toFixed(2);
   checkTap(f, now);
   if (capturing && !hasSensorAPI) {
     motionData.push({ t: now, ax: f.ax, ay: f.ay, az: f.az });
@@ -348,6 +351,7 @@ function handleSensorReading() {
     accelSensor?.z || 0
   );
   const now = performance.now();
+  yValueEl.textContent = f.ay.toFixed(2);
   checkTap(f, now);
   if (capturing) {
     motionData.push({ t: now, ax: f.ax, ay: f.ay, az: f.az });

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,0 +1,5 @@
+export const TAP_THRESHOLD = 15; // m/s^2 above gravity
+export const TAP_WINDOW = 400; // max ms between taps
+export const TAP_COOLDOWN = 3000; // ms to wait before next double tap
+export const NOISE_FLOOR = 0.1; // m/s^2 filter to ignore noise on X/Z
+export const NOISE_FLOOR_Y = 3; // only keep Y values greater than this


### PR DESCRIPTION
## Summary
- Display `help.png` in the help modal for clearer phone placement instructions
- Show real-time Y-axis value via a new label in the demo area
- Move tap and noise thresholds into a dedicated `settings.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bb288ae08324bd20463292828be1