### PR TITLE
Fix charts aspect ratio to 4:3

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -8,13 +8,13 @@
 /* Place 3D canvas below the three axis charts */
 #chart-3d {
   grid-column: 1 / -1;
-  height: 300px;
 }
 
-/* Responsive canvas sizing */
+/* Responsive canvas sizing with fixed 4:3 ratio */
 canvas {
   width: 100%;
-  height: 200px;
+  height: auto;
+  aspect-ratio: 4 / 3;
 }
 
 @media (max-width: 640px) {
@@ -22,13 +22,6 @@ canvas {
     grid-template-columns: 1fr;
   }
 
-  canvas {
-    height: 12vh;
-  }
-
-  #chart-3d {
-    height: 24vh;
-  }
 }
 
 /* Typography for sensor selector */
@@ -38,14 +31,6 @@ select {
 }
 
 @media (min-width: 768px) {
-  canvas {
-    height: 300px;
-  }
-
-  #chart-3d {
-    height: 400px;
-  }
-
   label,
   select {
     font-size: 1.25rem;

--- a/js/app.js
+++ b/js/app.js
@@ -57,6 +57,8 @@ class SensorController {
         options: {
           animation: false,
           responsive: true,
+          maintainAspectRatio: true,
+          aspectRatio: 4 / 3,
           scales: {
             x: { display: false },
             y: { suggestedMin: -10, suggestedMax: 10 }
@@ -69,10 +71,19 @@ class SensorController {
   init3DScene() {
     const canvas = document.getElementById('chart-3d');
     this.scene = new THREE.Scene();
-    this.camera = new THREE.PerspectiveCamera(45, 1, 0.1, 1000);
+    this.camera = new THREE.PerspectiveCamera(45, 4 / 3, 0.1, 1000);
     this.camera.position.z = 5;
     this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
-    this.renderer.setSize(canvas.clientWidth || 300, canvas.clientHeight || 300);
+    const width = canvas.clientWidth || 300;
+    const height = (width * 3) / 4;
+    this.renderer.setSize(width, height);
+    window.addEventListener('resize', () => {
+      const newWidth = canvas.clientWidth;
+      const newHeight = (newWidth * 3) / 4;
+      this.renderer.setSize(newWidth, newHeight);
+      this.camera.aspect = newWidth / newHeight;
+      this.camera.updateProjectionMatrix();
+    });
     const geometry = new THREE.BoxGeometry(1, 2, 0.1);
     const material = new THREE.MeshNormalMaterial();
     this.cube = new THREE.Mesh(geometry, material);


### PR DESCRIPTION
## Summary
- Ensure canvases use CSS `aspect-ratio: 4 / 3` for consistent sizing
- Configure Chart.js line charts to maintain a 4:3 aspect ratio
- Update 3D scene setup to follow 4:3 ratio and handle window resizes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bb4ea65083248b9bb5d32603068d