### PR TITLE
chore: enumerate platform sensors

### DIFF
--- a/js/jumpApp.js
+++ b/js/jumpApp.js
@@ -11,6 +11,7 @@ import {
   TAP_COOLDOWN,
   NOISE_FLOOR,
   NOISE_FLOOR_Y,
+  SENSOR_TYPES,
 } from './settings.js';
 
 const permBtn = document.getElementById('perm-btn');
@@ -23,7 +24,9 @@ const bodyEl = document.body;
 const defaultBg = getComputedStyle(bodyEl).backgroundColor;
 
 const isIOS = /iP(ad|hone|od)/i.test(navigator.userAgent);
-const hasSensorAPI = 'LinearAccelerationSensor' in window;
+const ACTIVE_SENSOR = isIOS ? SENSOR_TYPES.IOS : SENSOR_TYPES.ANDROID;
+const hasSensorAPI =
+  ACTIVE_SENSOR === SENSOR_TYPES.ANDROID && 'LinearAccelerationSensor' in window;
 
 let permissionGranted = false;
 let capturing = false;
@@ -335,7 +338,7 @@ function startSensorListener() {
   if (sensorListening) return;
   window.addEventListener('devicemotion', processMotion, { passive: true });
   window.addEventListener('deviceorientation', handleOrientation);
-  if (hasSensorAPI) {
+  if (ACTIVE_SENSOR === SENSOR_TYPES.ANDROID && hasSensorAPI) {
     accelSensor = new LinearAccelerationSensor({ frequency: 60 });
     accelSensor.addEventListener('reading', handleSensorReading);
     accelSensor.start();

--- a/js/settings.js
+++ b/js/settings.js
@@ -3,3 +3,9 @@ export const TAP_WINDOW = 400; // max ms between taps
 export const TAP_COOLDOWN = 3000; // ms to wait before next double tap
 export const NOISE_FLOOR = 0.1; // m/s^2 filter to ignore noise on X/Z
 export const NOISE_FLOOR_Y = 3; // only keep Y values greater than this
+
+// Enumerate the sensors used on each platform
+export const SENSOR_TYPES = Object.freeze({
+  ANDROID: 'LinearAccelerationSensor',
+  IOS: 'devicemotion',
+});


### PR DESCRIPTION
## Summary
- define platform sensor types via new `SENSOR_TYPES` enum in settings
- select active sensor based on platform in `jumpApp`
- only start `LinearAccelerationSensor` when Android uses it

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a84c8750108324bf900115594eb345